### PR TITLE
Add ack request configuration

### DIFF
--- a/etc/default/lowpan
+++ b/etc/default/lowpan
@@ -4,3 +4,5 @@ PAN="0x23"
 MAC="18:C0:FF:EE:1A:C0:FF:EE"
 # set IP6 to "" if not required; note: set a prefix length
 IP6="fdaa:bb:cc:dd::1/64"
+# Set ack requests (Only enable if all devices on your PAN support acks)
+ACKREQ=0

--- a/etc/systemd/system/lowpan.service
+++ b/etc/systemd/system/lowpan.service
@@ -7,7 +7,7 @@ Conflicts=lowpan_monitor
 EnvironmentFile=/etc/default/lowpan
 Type=oneshot
 User=root
-ExecStart=/usr/local/sbin/create_lowpan $CHN $PAN $MAC $IP6
+ExecStart=/usr/local/sbin/create_lowpan $CHN $PAN $MAC $IP6 $ACKREQ
 ExecStop=/usr/local/sbin/delete_lowpan
 RemainAfterExit=yes
 

--- a/usr/local/sbin/create_lowpan
+++ b/usr/local/sbin/create_lowpan
@@ -20,6 +20,7 @@ CHANNEL=$1
 PANID=$2
 LLADDR=$3
 IPADDR=$4
+ACKREQ=$5
 
 # check for wpan0
 ip link show wpan0 1> /dev/null 2>&1
@@ -52,6 +53,7 @@ else
 fi
 #set channel and activate device
 iwpan phy phy0 set channel 0 $CHANNEL
+iwpan dev wpan0 set ackreq_default $ACKREQ
 iwpan dev wpan0 set pan_id $PANID
 ip link set wpan0 up
 ip link set lowpan0 up


### PR DESCRIPTION
This patch adds a configuration option to enable ack requests by default on lowpan adapters.

Default is of course turned off, and a nice warning to only enable it when all devices support it is included